### PR TITLE
Document extra_s3_prefixes setup for integration testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ cp terraform.tfvars.example terraform.tfvars
 Edit `terraform.tfvars` with your account-specific values:
 
 ```hcl
-input_bucket_name = "my-group-vcf-data"
-genome_ref_bucket = "my-group-reference-genomes"
+input_bucket_name = "my-vcf-data"
+genome_ref_bucket = "my-reference-genomes"
 genome_ref_key    = "genomes/hg38/Homo_sapiens.GRCh38.dna.toplevel.fa.gz"
 ```
 
@@ -128,17 +128,17 @@ terraform destroy
 Upload a compressed VCF to the `input/` prefix in your bucket. The Lambda triggers automatically:
 
 ```bash
-aws s3 cp sample.vcf.gz s3://my-group-vcf-data/input/sample.vcf.gz
+aws s3 cp sample.vcf.gz s3://my-vcf-data/input/sample.vcf.gz
 ```
 
 The normalised file appears at the `output/` prefix:
 
 ```bash
 # Check it arrived
-aws s3 ls s3://my-group-vcf-data/output/sample.vcf.gz
+aws s3 ls s3://my-vcf-data/output/sample.vcf.gz
 
 # Download it
-aws s3 cp s3://my-group-vcf-data/output/sample.vcf.gz normalised_sample.vcf.gz
+aws s3 cp s3://my-vcf-data/output/sample.vcf.gz normalised_sample.vcf.gz
 ```
 
 ### Manual — re-process a file
@@ -146,7 +146,7 @@ aws s3 cp s3://my-group-vcf-data/output/sample.vcf.gz normalised_sample.vcf.gz
 Use the helper script to re-invoke the Lambda for a specific file:
 
 ```bash
-./scripts/invoke.sh my-group-vcf-data input/sample.vcf.gz
+./scripts/invoke.sh my-vcf-data input/sample.vcf.gz
 ```
 
 Or invoke directly with the AWS CLI:
@@ -154,7 +154,7 @@ Or invoke directly with the AWS CLI:
 ```bash
 aws lambda invoke \
   --function-name "$FUNCTION_NAME" \
-  --payload '{"bucket": "my-group-vcf-data", "key": "input/sample.vcf.gz"}' \
+  --payload '{"bucket": "my-vcf-data", "key": "input/sample.vcf.gz"}' \
   --cli-binary-format raw-in-base64-out \
   /dev/stdout
 ```

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,8 +1,8 @@
 # Account-specific configuration
 # Copy this file to terraform.tfvars and fill in the values.
 
-input_bucket_name = "my-group-vcf-data"
-genome_ref_bucket = "my-group-reference-genomes"
+input_bucket_name = "my-vcf-data"
+genome_ref_bucket = "my-reference-genomes"
 genome_ref_key    = "genomes/hg38/Homo_sapiens.GRCh38.dna.toplevel.fa.gz"  # .fa or .fa.gz
 
 # Optional overrides


### PR DESCRIPTION
## Summary

- Add commented `extra_s3_prefixes` example to `terraform.tfvars.example`
- Add setup step in README explaining that the Lambda IAM policy needs the test prefixes granted via Terraform before running the integration test

## Test plan

- [x] Integration test passes with 100/100 VCFs after following the documented setup steps

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/normalisation/6)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples and commands to use new S3 bucket names (e.g. "my-vcf-data" and "my-reference-genomes") throughout the docs.
  * Revised test setup flow: added a two-step process to grant test prefixes and reordered steps so prefix grants occur before uploading test data.
  * Added a commented example showing how to grant read/write access to additional S3 prefixes for integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->