### PR TITLE
Document terraform import steps for fresh-clone updates, add provider block

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ aws lambda update-function-code \
   --image-uri "$ECR_REPO:latest"
 ```
 
+#### Updating from a different machine
+
+If you are running these steps on a machine that has no local Terraform state (e.g. a fresh clone), Terraform will not know about the existing resources and `terraform apply` will fail. Import the resources that already exist in AWS before applying:
+
+```bash
+cd terraform
+terraform import aws_iam_role.lambda vcf-normalisation-lambda
+terraform import aws_lambda_permission.s3 vcf-normalisation/AllowS3Invoke
+```
+
+Replace `vcf-normalisation` with your `project_name` if you changed the default. After importing, run `terraform apply` as normal.
+
 ### Tearing down
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ If you are running these steps on a machine that has no local Terraform state (e
 
 ```bash
 cd terraform
+terraform import aws_ecr_repository.this vcf-normalisation
 terraform import aws_iam_role.lambda vcf-normalisation-lambda
+terraform import aws_lambda_function.normalise vcf-normalisation
 terraform import aws_lambda_permission.s3 vcf-normalisation/AllowS3Invoke
 ```
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,10 @@ terraform {
   }
 }
 
+provider "aws" {
+  region = "eu-west-2"
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 


### PR DESCRIPTION
## Summary

- Adds a new \"Updating from a different machine\" subsection to the README explaining that `terraform import` is needed when no local state exists (e.g. fresh clone)
- Documents the two required import commands: `aws_iam_role.lambda` and `aws_lambda_permission.s3`
- Adds the `provider "aws"` block with `region = "eu-west-2"` to `terraform/main.tf`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NHS-NGS/normalisation/11)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for updating infrastructure from a different machine, including steps to import existing Terraform-managed resources before applying changes.

* **Infrastructure**
  * Set the AWS provider region to eu-west-2 to ensure consistent infrastructure operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->