### PR TITLE
chore: ignore venv, EDA artefacts, and session notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,12 @@ integration_report.md
 
 # OS
 .DS_Store
+
+# Virtual environments
+.venv/
+
+# EDA / analysis artefacts (downstream use, not part of pipeline)
+eda_haemonc_v3_norm.py
+haemonc_v3_norm_eda.ipynb
+haemonc_v3_norm_eda.html
+vcf_normalisation_session_*.md


### PR DESCRIPTION
## Summary
- Add `.venv/` to `.gitignore` (virtual environment created during EDA session)
- Ignore `eda_haemonc_v3_norm.py`, `haemonc_v3_norm_eda.ipynb`, `haemonc_v3_norm_eda.html` — downstream analysis artefacts for the haemonc variant store EDA, not part of the pipeline
- Ignore `vcf_normalisation_session_*.md` — session notes

## Test plan
- [ ] Verify `.gitignore` correctly suppresses the listed files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NHS-NGS/normalisation/12)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude development artifacts and analysis output files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->