### PR TITLE
feat: support multiple reference genomes per deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,12 @@ integration_report.md
 
 # OS
 .DS_Store
+
+# Virtual environments
+.venv/
+
+# EDA / analysis artefacts (downstream use, not part of pipeline)
+eda_haemonc_v3_norm.py
+haemonc_v3_norm_eda.ipynb
+haemonc_v3_norm_eda.html
+vcf_normalisation_session_*.md

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Serverless pipeline that normalises VCF files using `bcftools norm`. Deployed as
 ## Architecture
 
 ```text
-S3 (input/)  →  S3 Event Notification  →  Lambda (bcftools container)  →  S3 (output/)
+S3 (input/<genome>/)  →  S3 Event Notification  →  Lambda (bcftools container)  →  S3 (output/<genome>/)
 ```
 
-Each of the 7 groups deploys the same Terraform module into their own AWS account.
+Each of the 7 groups deploys the same Terraform module into their own AWS account. A single deployment can serve **multiple reference genomes** — each genome gets its own Lambda function and IAM role, all sharing one ECR repository and one S3 bucket notification.
 
 ## Prerequisites
 
@@ -37,15 +37,25 @@ cd terraform
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-Edit `terraform.tfvars` with your account-specific values:
+Edit `terraform.tfvars` with your account-specific values. The `genome_configs` list contains one entry per reference genome. Single-genome accounts supply one entry; add more entries to enable additional genomes:
 
 ```hcl
 input_bucket_name = "my-vcf-data"
-genome_ref_bucket = "my-reference-genomes"
-genome_ref_key    = "genomes/hg38/Homo_sapiens.GRCh38.dna.toplevel.fa.gz"
+
+genome_configs = [
+  {
+    name              = "grch38"
+    input_prefix      = "input/grch38/"
+    output_prefix     = "output/grch38/"
+    genome_ref_bucket = "my-reference-genomes"
+    genome_ref_key    = "genomes/GRCh38/genome.fa.gz"
+  },
+]
 ```
 
-The following index files must exist alongside the genome in the same bucket:
+Each entry creates a separate Lambda function named `<project_name>-<name>` (e.g. `vcf-normalisation-grch38`). The `name` field is a short identifier used in resource names — it can be any unique string (e.g. `grch38`, `hg19`, `grch37`).
+
+The following index files must exist alongside each genome in the same bucket:
 
 - **Uncompressed genome** (`.fa`): requires `.fa.fai`
 - **Bgzipped genome** (`.fa.gz`): requires `.fa.gz.fai` and `.fa.gz.gzi`
@@ -96,7 +106,7 @@ cd terraform
 terraform apply
 ```
 
-This creates the Lambda function, IAM roles, and S3 event notification using the image you just pushed.
+This creates one Lambda function and IAM role per `genome_configs` entry, plus the shared S3 event notification.
 
 ### Updating the Lambda
 
@@ -107,23 +117,24 @@ sudo docker build -t vcf-normalisation .
 sudo docker tag vcf-normalisation:latest "$ECR_REPO:latest"
 sudo docker push "$ECR_REPO:latest"
 
-# Force Lambda to pick up the new image
-FUNCTION_NAME=$(cd terraform && terraform output -raw lambda_function_name)
-aws lambda update-function-code \
-  --function-name "$FUNCTION_NAME" \
-  --image-uri "$ECR_REPO:latest"
+# Force all genome Lambdas to pick up the new image
+terraform output -json lambda_function_names \
+  | jq -r '.[]' \
+  | xargs -I{} aws lambda update-function-code \
+      --function-name {} \
+      --image-uri "$ECR_REPO:latest"
 ```
 
 #### Updating from a different machine
 
-If you are running these steps on a machine that has no local Terraform state (e.g. a fresh clone), Terraform will not know about the existing resources and `terraform apply` will fail. Import the resources that already exist in AWS before applying:
+If you are running these steps on a machine that has no local Terraform state (e.g. a fresh clone), import the existing resources before applying. The resources are now keyed by genome name, so substitute `<name>` with your `genome_configs` entry name (e.g. `grch38`):
 
 ```bash
 cd terraform
 terraform import aws_ecr_repository.this vcf-normalisation
-terraform import aws_iam_role.lambda vcf-normalisation-lambda
-terraform import aws_lambda_function.normalise vcf-normalisation
-terraform import aws_lambda_permission.s3 vcf-normalisation/AllowS3Invoke
+terraform import 'module.normaliser["<name>"].aws_iam_role.lambda' vcf-normalisation-<name>-lambda
+terraform import 'module.normaliser["<name>"].aws_lambda_function.normalise' vcf-normalisation-<name>
+terraform import 'module.normaliser["<name>"].aws_lambda_permission.s3' vcf-normalisation-<name>/AllowS3Invoke
 ```
 
 Replace `vcf-normalisation` with your `project_name` if you changed the default. After importing, run `terraform apply` as normal.
@@ -139,61 +150,53 @@ terraform destroy
 
 ### Automatic — upload a file
 
-Upload a VCF to the `input/` prefix in your bucket. Both gzipped (`.vcf.gz`) and uncompressed (`.vcf`) inputs are accepted. The Lambda triggers automatically:
+Upload a VCF to the genome-specific `input/` prefix in your bucket. Both gzipped (`.vcf.gz`) and uncompressed (`.vcf`) inputs are accepted. The Lambda triggers automatically:
 
 ```bash
-aws s3 cp sample.vcf.gz s3://my-vcf-data/input/sample.vcf.gz
-# or
-aws s3 cp sample.vcf s3://my-vcf-data/input/sample.vcf
+aws s3 cp sample.vcf.gz s3://my-vcf-data/input/grch38/sample.vcf.gz
 ```
 
-The normalised file appears at the `output/` prefix. Output is always bgzipped (`.vcf.gz`), regardless of whether the input was compressed:
+The normalised file appears under the corresponding `output/` prefix. Output is always bgzipped (`.vcf.gz`), regardless of whether the input was compressed:
 
 ```bash
 # Check it arrived
-aws s3 ls s3://my-vcf-data/output/sample.vcf.gz
+aws s3 ls s3://my-vcf-data/output/grch38/sample.vcf.gz
 
 # Download it
-aws s3 cp s3://my-vcf-data/output/sample.vcf.gz normalised_sample.vcf.gz
+aws s3 cp s3://my-vcf-data/output/grch38/sample.vcf.gz normalised_sample.vcf.gz
 ```
 
 ### Manual — re-process a file
 
-Use the helper script to re-invoke the Lambda for a specific file:
+Use the helper script to re-invoke a specific Lambda. The `FUNCTION_NAME` env var selects which genome's Lambda to use (defaults to `vcf-normalisation`):
 
 ```bash
-./scripts/invoke.sh my-vcf-data input/sample.vcf.gz
+FUNCTION_NAME=vcf-normalisation-grch38 ./scripts/invoke.sh my-vcf-data input/grch38/sample.vcf.gz
 ```
 
 Or invoke directly with the AWS CLI:
 
 ```bash
 aws lambda invoke \
-  --function-name "$FUNCTION_NAME" \
-  --payload '{"bucket": "my-vcf-data", "key": "input/sample.vcf.gz"}' \
+  --function-name vcf-normalisation-grch38 \
+  --payload '{"bucket": "my-vcf-data", "key": "input/grch38/sample.vcf.gz"}' \
   --cli-binary-format raw-in-base64-out \
   /dev/stdout
 ```
 
 ### Monitoring
 
-Set the function name from Terraform output (or use the `FUNCTION_NAME` env var from earlier steps):
+List all Lambda function names from the Terraform output:
 
 ```bash
-FUNCTION_NAME=$(cd terraform && terraform output -raw lambda_function_name)
+terraform -chdir=terraform output -json lambda_function_names
+# {"grch38": "vcf-normalisation-grch38", "hg19": "vcf-normalisation-hg19"}
 ```
 
 View Lambda logs in CloudWatch:
 
 ```bash
-aws logs tail "/aws/lambda/$FUNCTION_NAME" --follow
-```
-
-Check for invocation errors:
-
-```bash
-aws lambda get-function --function-name "$FUNCTION_NAME" \
-  --query 'Configuration.{State:State,LastModified:LastModified}'
+aws logs tail "/aws/lambda/vcf-normalisation-grch38" --follow
 ```
 
 ## Configuration
@@ -203,15 +206,22 @@ See `terraform/variables.tf` for all options. Key variables:
 | Variable | Description | Default |
 |---|---|---|
 | `input_bucket_name` | S3 bucket for VCF uploads | (required) |
-| `genome_ref_bucket` | S3 bucket with reference genome | (required) |
-| `genome_ref_key` | S3 key for the genome (`.fa` or `.fa.gz`) | (required) |
-| `input_prefix` | S3 prefix that triggers Lambda | `input/` |
-| `output_prefix` | S3 prefix for normalised output | `output/` |
-| `lambda_memory_mb` | Lambda memory (MB) | 2048 |
-| `lambda_timeout` | Lambda timeout (seconds) | 600 |
-| `lambda_ephemeral_storage_mb` | Ephemeral `/tmp` storage (MB) | 4096 |
+| `genome_configs` | List of genome/prefix configurations (see below) | (required) |
+| `lambda_memory_mb` | Lambda memory (MB) — applies to all Lambdas | 2048 |
+| `lambda_timeout` | Lambda timeout (seconds) — applies to all Lambdas | 600 |
+| `lambda_ephemeral_storage_mb` | Ephemeral `/tmp` storage (MB) — applies to all Lambdas | 4096 |
 | `ecr_image_tag` | Container image tag to deploy | `latest` |
-| `extra_s3_prefixes` | Extra read/write S3 prefix pairs for Lambda (e.g. testing) | `[]` |
+
+### `genome_configs` fields
+
+| Field | Description |
+|---|---|
+| `name` | Short identifier used in resource names (e.g. `grch38`, `hg19`) — must be unique |
+| `input_prefix` | S3 prefix to watch for incoming VCFs (must end with `/`) |
+| `output_prefix` | S3 prefix where normalised VCFs are written (must end with `/`) |
+| `genome_ref_bucket` | S3 bucket containing the reference FASTA |
+| `genome_ref_key` | S3 key for the FASTA (`.fai` must be at `<key>.fai`) |
+| `extra_s3_prefixes` | Optional list of `{read_prefix, write_prefix}` pairs (e.g. for integration testing) |
 
 ## Testing
 
@@ -259,14 +269,23 @@ AWS CLI v2 must be installed separately — see the [AWS CLI installation guide]
 
 #### Setup
 
-1. Grant the Lambda access to the test prefixes by adding the following to `terraform.tfvars` and running `terraform apply`:
+1. Grant the Lambda access to the test prefixes by adding `extra_s3_prefixes` to the relevant entry in `genome_configs` and running `terraform apply`:
 
 ```hcl
-extra_s3_prefixes = [
+genome_configs = [
   {
-    read_prefix  = "test/input/"
-    write_prefix = "test/output/"
-  }
+    name              = "grch38"
+    input_prefix      = "input/grch38/"
+    output_prefix     = "output/grch38/"
+    genome_ref_bucket = "my-reference-genomes"
+    genome_ref_key    = "genomes/GRCh38/genome.fa.gz"
+    extra_s3_prefixes = [
+      {
+        read_prefix  = "test/input/"
+        write_prefix = "test/output/"
+      }
+    ]
+  },
 ]
 ```
 
@@ -280,7 +299,7 @@ aws s3 sync ./expected_vcfs/ s3://my-vcf-data/test/expected/
 #### Running
 
 ```bash
-./scripts/integration_test.sh <bucket> [input_prefix] [expected_prefix]
+FUNCTION_NAME=vcf-normalisation-grch38 ./scripts/integration_test.sh <bucket> [input_prefix] [expected_prefix]
 ```
 
 | Parameter | Source | Default |
@@ -296,7 +315,7 @@ aws s3 sync ./expected_vcfs/ s3://my-vcf-data/test/expected/
 Example:
 
 ```bash
-MAX_PARALLEL=20 ./scripts/integration_test.sh my-vcf-data
+MAX_PARALLEL=20 FUNCTION_NAME=vcf-normalisation-grch38 ./scripts/integration_test.sh my-vcf-data
 ```
 
 ## AWS permissions
@@ -309,8 +328,8 @@ The user or CI role running `terraform apply` and pushing the container image ne
 |---------|-------------|--------|
 | ECR | `ecr:CreateRepository`, `ecr:DeleteRepository`, `ecr:PutLifecyclePolicy`, `ecr:DescribeRepositories`, `ecr:ListTagsForResource`, `ecr:TagResource` | Create and manage the container repository |
 | ECR (image push) | `ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`, `ecr:PutImage`, `ecr:InitiateLayerUpload`, `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload` | Authenticate Docker and push images |
-| Lambda | `lambda:CreateFunction`, `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`, `lambda:DeleteFunction`, `lambda:GetFunction`, `lambda:AddPermission`, `lambda:RemovePermission`, `lambda:TagResource`, `lambda:ListTags` | Create and update the Lambda function |
-| IAM | `iam:CreateRole`, `iam:DeleteRole`, `iam:AttachRolePolicy`, `iam:DetachRolePolicy`, `iam:PutRolePolicy`, `iam:DeleteRolePolicy`, `iam:GetRole`, `iam:GetRolePolicy`, `iam:PassRole`, `iam:ListRolePolicies`, `iam:ListAttachedRolePolicies`, `iam:ListInstanceProfilesForRole`, `iam:TagRole` | Manage the Lambda execution role |
+| Lambda | `lambda:CreateFunction`, `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`, `lambda:DeleteFunction`, `lambda:GetFunction`, `lambda:AddPermission`, `lambda:RemovePermission`, `lambda:TagResource`, `lambda:ListTags` | Create and update Lambda functions |
+| IAM | `iam:CreateRole`, `iam:DeleteRole`, `iam:AttachRolePolicy`, `iam:DetachRolePolicy`, `iam:PutRolePolicy`, `iam:DeleteRolePolicy`, `iam:GetRole`, `iam:GetRolePolicy`, `iam:PassRole`, `iam:ListRolePolicies`, `iam:ListAttachedRolePolicies`, `iam:ListInstanceProfilesForRole`, `iam:TagRole` | Manage Lambda execution roles |
 | S3 | `s3:GetBucketNotification`, `s3:PutBucketNotification` | Configure the S3 event trigger |
 | S3 (data source) | `s3:ListBucket`, `s3:GetBucketLocation` | Terraform data source to reference the existing bucket |
 | STS | `sts:GetCallerIdentity` | Terraform uses this to determine the account ID |
@@ -321,8 +340,8 @@ Users who upload VCFs or manually invoke the Lambda need:
 
 | Service | Permissions | Reason |
 |---------|-------------|--------|
-| S3 | `s3:PutObject` on `input/*` | Upload input VCFs |
-| S3 | `s3:GetObject` on `output/*` | Download normalised results |
+| S3 | `s3:PutObject` on `input/<genome>/*` | Upload input VCFs |
+| S3 | `s3:GetObject` on `output/<genome>/*` | Download normalised results |
 | S3 | `s3:ListBucket` | List objects in input/output prefixes |
 | Lambda | `lambda:InvokeFunction` | Manual invocation via `invoke.sh` or AWS CLI |
 | CloudWatch Logs | `logs:FilterLogEvents`, `logs:GetLogEvents` | View Lambda logs for monitoring |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ genome_configs = [
 ]
 ```
 
-Each entry creates a separate Lambda function named `<project_name>-<name>` (e.g. `vcf-normalisation-grch38`). The `name` field is a short identifier used in resource names — it can be any unique string (e.g. `grch38`, `hg19`, `grch37`).
+Each entry creates a separate Lambda function named `<project_name>-<name>` (e.g. `vcf-normalisation-grch38`). The `name` field is a short identifier used in resource names — it must be unique and contain only letters, numbers, hyphens, and underscores (e.g. `grch38`, `hg19`, `grch37`).
 
 The following index files must exist alongside each genome in the same bucket:
 
@@ -168,7 +168,7 @@ aws s3 cp s3://my-vcf-data/output/grch38/sample.vcf.gz normalised_sample.vcf.gz
 
 ### Manual — re-process a file
 
-Use the helper script to re-invoke a specific Lambda. The `FUNCTION_NAME` env var selects which genome's Lambda to use (defaults to `vcf-normalisation`):
+Use the helper script to re-invoke a specific Lambda. `FUNCTION_NAME` must be set to the deployed function name:
 
 ```bash
 FUNCTION_NAME=vcf-normalisation-grch38 ./scripts/invoke.sh my-vcf-data input/grch38/sample.vcf.gz
@@ -307,7 +307,7 @@ FUNCTION_NAME=vcf-normalisation-grch38 ./scripts/integration_test.sh <bucket> [i
 | `BUCKET` | Arg 1 | (required) |
 | `INPUT_PREFIX` | Arg 2 | `test/input/` |
 | `EXPECTED_PREFIX` | Arg 3 | `test/expected/` |
-| `FUNCTION_NAME` | Env var | `vcf-normalisation` |
+| `FUNCTION_NAME` | Env var | (required — no default) |
 | `MAX_PARALLEL` | Env var | `10` |
 | `POLL_TIMEOUT` | Env var | `120` (seconds per file) |
 | `REPORT_FILE` | Env var | `integration_report.md` |

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -29,7 +29,7 @@ fi
 BUCKET="$1"
 INPUT_PREFIX="${2:-test/input/}"
 EXPECTED_PREFIX="${3:-test/expected/}"
-FUNCTION_NAME="${FUNCTION_NAME:-vcf-normalisation}"
+FUNCTION_NAME="${FUNCTION_NAME:?FUNCTION_NAME must be set (e.g. vcf-normalisation-grch38)}"
 MAX_PARALLEL="${MAX_PARALLEL:-10}"
 POLL_TIMEOUT="${POLL_TIMEOUT:-120}"
 REPORT_FILE="${REPORT_FILE:-integration_report.md}"

--- a/scripts/invoke.sh
+++ b/scripts/invoke.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-FUNCTION_NAME="${FUNCTION_NAME:-vcf-normalisation}"
+FUNCTION_NAME="${FUNCTION_NAME:?FUNCTION_NAME must be set (e.g. vcf-normalisation-grch38)}"
 
 if [[ $# -ne 2 ]]; then
     echo "Usage: $0 <bucket> <key>" >&2

--- a/technical_walkthrough.md
+++ b/technical_walkthrough.md
@@ -3,7 +3,7 @@
 *2026-02-19T22:40:27Z by Showboat 0.6.0*
 <!-- showboat-id: ee047990-1b34-4542-b149-b846ac76e849 -->
 
-A serverless pipeline that normalises VCF files using `bcftools norm`. An S3 upload to the `input/` prefix triggers a Lambda function (packaged as a container image with bcftools), which left-aligns indels, splits multiallelic sites, and preserves allelic depth sums. Both gzipped (`.vcf.gz`) and uncompressed (`.vcf`) inputs are accepted; output is always bgzipped. The normalised VCF is written to the `output/` prefix in the same bucket. The same Terraform module is deployed across 7 AWS accounts.
+A serverless pipeline that normalises VCF files using `bcftools norm`. An S3 upload to a genome-specific `input/<genome>/` prefix triggers a Lambda function (packaged as a container image with bcftools), which left-aligns indels, splits multiallelic sites, and preserves allelic depth sums. Both gzipped (`.vcf.gz`) and uncompressed (`.vcf`) inputs are accepted; output is always bgzipped. The normalised VCF is written to the corresponding `output/<genome>/` prefix in the same bucket. The same Terraform module is deployed across 7 AWS accounts. A single deployment can serve multiple reference genomes — each genome gets its own Lambda function and IAM role, all sharing one ECR repository.
 
 ## Project Structure
 
@@ -21,13 +21,16 @@ find . -type f \( -name '*.py' -o -name '*.tf' -o -name '*.sh' -o -name 'Dockerf
 ```
 
 ```bash
-ls terraform/*.tf
+ls terraform/*.tf terraform/modules/vcf_normaliser/*.tf
 ```
 
 ```output
 terraform/main.tf
 terraform/outputs.tf
 terraform/variables.tf
+terraform/modules/vcf_normaliser/main.tf
+terraform/modules/vcf_normaliser/outputs.tf
+terraform/modules/vcf_normaliser/variables.tf
 ```
 
 ## Lambda Handler
@@ -409,7 +412,19 @@ set -euo pipefail
 
 ## Infrastructure
 
-Terraform manages the ECR repository, Lambda function, IAM roles, and S3 event notification. Key variables allow per-account customisation (bucket names, genome reference path, memory/timeout settings).
+Terraform manages the ECR repository, Lambda functions, IAM roles, and S3 event notification. The configuration is split into a root module and a reusable child module.
+
+**Root module** (`terraform/`) owns resources that are shared across all genome configs or that must be defined once per bucket:
+- `aws_ecr_repository` / `aws_ecr_lifecycle_policy` — one shared image repository
+- `module.normaliser` (`for_each` over `genome_configs`) — one child module instance per genome
+- `aws_s3_bucket_notification` — a single resource with dynamic blocks (S3 only allows one notification resource per bucket)
+
+**Child module** (`terraform/modules/vcf_normaliser/`) owns the per-genome resources:
+- `aws_iam_role` + `aws_iam_role_policy_attachment` + `aws_iam_role_policy`
+- `aws_lambda_function`
+- `aws_lambda_permission`
+
+Key variables allow per-account customisation (bucket names, genome reference paths, memory/timeout settings).
 
 ```bash
 grep '^variable' terraform/variables.tf
@@ -418,15 +433,11 @@ grep '^variable' terraform/variables.tf
 ```output
 variable "project_name" {
 variable "input_bucket_name" {
-variable "input_prefix" {
-variable "output_prefix" {
-variable "genome_ref_bucket" {
-variable "genome_ref_key" {
+variable "genome_configs" {
 variable "lambda_memory_mb" {
 variable "lambda_timeout" {
 variable "lambda_ephemeral_storage_mb" {
 variable "ecr_image_tag" {
-variable "extra_s3_prefixes" {
 variable "tags" {
 ```
 
@@ -435,16 +446,10 @@ grep '^resource\|^data\|^module' terraform/main.tf
 ```
 
 ```output
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
+data "aws_s3_bucket" "input" {
 resource "aws_ecr_repository" "this" {
 resource "aws_ecr_lifecycle_policy" "this" {
-resource "aws_iam_role" "lambda" {
-resource "aws_iam_role_policy_attachment" "lambda_basic" {
-resource "aws_iam_role_policy" "lambda_s3" {
-data "aws_s3_bucket" "input" {
-resource "aws_lambda_function" "normalise" {
-resource "aws_lambda_permission" "s3" {
+module "normaliser" {
 resource "aws_s3_bucket_notification" "input" {
 ```
 
@@ -452,31 +457,35 @@ resource "aws_s3_bucket_notification" "input" {
 
 The pipeline accepts both gzipped (`.vcf.gz`) and uncompressed (`.vcf`) VCF files. Two changes enable this.
 
-**S3 trigger** — the Terraform notification resource registers two filter blocks, one per suffix, so uploads of either format fire the Lambda:
+**S3 trigger** — the Terraform notification resource uses `dynamic` blocks to generate one trigger per (genome config × file suffix) combination, so uploads of either format to any configured prefix fire the correct Lambda:
 
 ```bash
-grep -A 18 "aws_s3_bucket_notification" terraform/main.tf
+grep -A 22 "aws_s3_bucket_notification" terraform/main.tf
 ```
 
 ```output
 resource "aws_s3_bucket_notification" "input" {
   bucket = data.aws_s3_bucket.input.id
 
-  lambda_function {
-    lambda_function_arn = aws_lambda_function.normalise.arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = var.input_prefix
-    filter_suffix       = ".vcf.gz"
+  dynamic "lambda_function" {
+    for_each = {
+      for pair in flatten([
+        for cfg in var.genome_configs : [
+          { key = "${cfg.name}-vcfgz", name = cfg.name, prefix = cfg.input_prefix, suffix = ".vcf.gz" },
+          { key = "${cfg.name}-vcf",   name = cfg.name, prefix = cfg.input_prefix, suffix = ".vcf" },
+        ]
+      ]) : pair.key => pair
+    }
+
+    content {
+      lambda_function_arn = module.normaliser[lambda_function.value.name].lambda_function_arn
+      events              = ["s3:ObjectCreated:*"]
+      filter_prefix       = lambda_function.value.prefix
+      filter_suffix       = lambda_function.value.suffix
+    }
   }
 
-  lambda_function {
-    lambda_function_arn = aws_lambda_function.normalise.arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = var.input_prefix
-    filter_suffix       = ".vcf"
-  }
-
-  depends_on = [aws_lambda_permission.s3]
+  depends_on = [module.normaliser]
 }
 ```
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,11 +13,12 @@ provider "aws" {
   region = "eu-west-2"
 }
 
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
+data "aws_s3_bucket" "input" {
+  bucket = var.input_bucket_name
+}
 
 # ---------------------------------------------------------------------------
-# ECR Repository
+# ECR Repository — shared across all genome configs (same container image)
 # ---------------------------------------------------------------------------
 
 resource "aws_ecr_repository" "this" {
@@ -52,140 +53,56 @@ resource "aws_ecr_lifecycle_policy" "this" {
 }
 
 # ---------------------------------------------------------------------------
-# IAM Role for Lambda
+# One Lambda + IAM role per genome config
 # ---------------------------------------------------------------------------
 
-resource "aws_iam_role" "lambda" {
-  name = "${var.project_name}-lambda"
+module "normaliser" {
+  for_each = { for cfg in var.genome_configs : cfg.name => cfg }
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        Service = "lambda.amazonaws.com"
-      }
-    }]
-  })
+  source = "./modules/vcf_normaliser"
 
-  tags = var.tags
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_basic" {
-  role       = aws_iam_role.lambda.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
-resource "aws_iam_role_policy" "lambda_s3" {
-  name = "${var.project_name}-s3-access"
-  role = aws_iam_role.lambda.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "ReadInputBucket"
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-        ]
-        Resource = concat(
-          ["${data.aws_s3_bucket.input.arn}/${var.input_prefix}*"],
-          [for p in var.extra_s3_prefixes : "${data.aws_s3_bucket.input.arn}/${p.read_prefix}*"],
-        )
-      },
-      {
-        Sid    = "WriteOutputBucket"
-        Effect = "Allow"
-        Action = [
-          "s3:PutObject",
-        ]
-        Resource = concat(
-          ["${data.aws_s3_bucket.input.arn}/${var.output_prefix}*"],
-          [for p in var.extra_s3_prefixes : "${data.aws_s3_bucket.input.arn}/${p.write_prefix}*"],
-        )
-      },
-      {
-        Sid    = "ReadGenomeRef"
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-        ]
-        Resource = [
-          "arn:aws:s3:::${var.genome_ref_bucket}/${var.genome_ref_key}",
-          "arn:aws:s3:::${var.genome_ref_bucket}/${var.genome_ref_key}.fai",
-          "arn:aws:s3:::${var.genome_ref_bucket}/${var.genome_ref_key}.gzi",
-        ]
-      },
-    ]
-  })
+  project_name                = var.project_name
+  name                        = each.value.name
+  input_bucket_arn            = data.aws_s3_bucket.input.arn
+  input_prefix                = each.value.input_prefix
+  output_prefix               = each.value.output_prefix
+  genome_ref_bucket           = each.value.genome_ref_bucket
+  genome_ref_key              = each.value.genome_ref_key
+  lambda_memory_mb            = var.lambda_memory_mb
+  lambda_timeout              = var.lambda_timeout
+  lambda_ephemeral_storage_mb = var.lambda_ephemeral_storage_mb
+  ecr_image_uri               = "${aws_ecr_repository.this.repository_url}:${var.ecr_image_tag}"
+  extra_s3_prefixes           = each.value.extra_s3_prefixes
+  tags                        = var.tags
 }
 
 # ---------------------------------------------------------------------------
-# S3 Bucket (data source — bucket must already exist)
+# S3 Event Notification — single resource covers all genome configs
+# S3 only permits one aws_s3_bucket_notification per bucket; dynamic blocks
+# generate one trigger block per (genome_config × file_suffix) combination.
 # ---------------------------------------------------------------------------
-
-data "aws_s3_bucket" "input" {
-  bucket = var.input_bucket_name
-}
-
-# ---------------------------------------------------------------------------
-# Lambda Function
-# ---------------------------------------------------------------------------
-
-resource "aws_lambda_function" "normalise" {
-  function_name = var.project_name
-  role          = aws_iam_role.lambda.arn
-  package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.this.repository_url}:${var.ecr_image_tag}"
-  timeout       = var.lambda_timeout
-  memory_size   = var.lambda_memory_mb
-
-  ephemeral_storage {
-    size = var.lambda_ephemeral_storage_mb
-  }
-
-  environment {
-    variables = {
-      GENOME_REF_BUCKET = var.genome_ref_bucket
-      GENOME_REF_KEY    = var.genome_ref_key
-      OUTPUT_PREFIX     = var.output_prefix
-    }
-  }
-
-  tags = var.tags
-}
-
-# ---------------------------------------------------------------------------
-# S3 Event Notification → Lambda
-# ---------------------------------------------------------------------------
-
-resource "aws_lambda_permission" "s3" {
-  statement_id  = "AllowS3Invoke"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.normalise.function_name
-  principal     = "s3.amazonaws.com"
-  source_arn    = data.aws_s3_bucket.input.arn
-  source_account = data.aws_caller_identity.current.account_id
-}
 
 resource "aws_s3_bucket_notification" "input" {
   bucket = data.aws_s3_bucket.input.id
 
-  lambda_function {
-    lambda_function_arn = aws_lambda_function.normalise.arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = var.input_prefix
-    filter_suffix       = ".vcf.gz"
+  dynamic "lambda_function" {
+    for_each = {
+      for pair in flatten([
+        for cfg in var.genome_configs : [
+          { key = "${cfg.name}-vcfgz", name = cfg.name, prefix = cfg.input_prefix, suffix = ".vcf.gz" },
+          { key = "${cfg.name}-vcf",   name = cfg.name, prefix = cfg.input_prefix, suffix = ".vcf" },
+        ]
+      ]) : pair.key => pair
+    }
+
+    content {
+      lambda_function_arn = module.normaliser[lambda_function.value.name].lambda_function_arn
+      events              = ["s3:ObjectCreated:*"]
+      filter_prefix       = lambda_function.value.prefix
+      filter_suffix       = lambda_function.value.suffix
+    }
   }
 
-  lambda_function {
-    lambda_function_arn = aws_lambda_function.normalise.arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = var.input_prefix
-    filter_suffix       = ".vcf"
-  }
-
-  depends_on = [aws_lambda_permission.s3]
+  # Lambda permissions must exist before S3 can register the notification
+  depends_on = [module.normaliser]
 }

--- a/terraform/modules/vcf_normaliser/main.tf
+++ b/terraform/modules/vcf_normaliser/main.tf
@@ -1,0 +1,110 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  resource_name = "${var.project_name}-${var.name}"
+}
+
+# ---------------------------------------------------------------------------
+# IAM Role for Lambda
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "lambda" {
+  name = "${local.resource_name}-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "lambda_s3" {
+  name = "${local.resource_name}-s3-access"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadInputBucket"
+        Effect = "Allow"
+        Action = ["s3:GetObject"]
+        Resource = concat(
+          ["${var.input_bucket_arn}/${var.input_prefix}*"],
+          [for p in var.extra_s3_prefixes : "${var.input_bucket_arn}/${p.read_prefix}*"],
+        )
+      },
+      {
+        Sid    = "WriteOutputBucket"
+        Effect = "Allow"
+        Action = ["s3:PutObject"]
+        Resource = concat(
+          ["${var.input_bucket_arn}/${var.output_prefix}*"],
+          [for p in var.extra_s3_prefixes : "${var.input_bucket_arn}/${p.write_prefix}*"],
+        )
+      },
+      {
+        Sid    = "ReadGenomeRef"
+        Effect = "Allow"
+        Action = ["s3:GetObject"]
+        Resource = [
+          "arn:aws:s3:::${var.genome_ref_bucket}/${var.genome_ref_key}",
+          "arn:aws:s3:::${var.genome_ref_bucket}/${var.genome_ref_key}.fai",
+          "arn:aws:s3:::${var.genome_ref_bucket}/${var.genome_ref_key}.gzi",
+        ]
+      },
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Lambda Function
+# ---------------------------------------------------------------------------
+
+resource "aws_lambda_function" "normalise" {
+  function_name = local.resource_name
+  role          = aws_iam_role.lambda.arn
+  package_type  = "Image"
+  image_uri     = var.ecr_image_uri
+  timeout       = var.lambda_timeout
+  memory_size   = var.lambda_memory_mb
+
+  ephemeral_storage {
+    size = var.lambda_ephemeral_storage_mb
+  }
+
+  environment {
+    variables = {
+      GENOME_REF_BUCKET = var.genome_ref_bucket
+      GENOME_REF_KEY    = var.genome_ref_key
+      OUTPUT_PREFIX     = var.output_prefix
+    }
+  }
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------
+# Lambda Permission (allows S3 to invoke this function)
+# ---------------------------------------------------------------------------
+
+resource "aws_lambda_permission" "s3" {
+  statement_id   = "AllowS3Invoke"
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.normalise.function_name
+  principal      = "s3.amazonaws.com"
+  source_arn     = var.input_bucket_arn
+  source_account = data.aws_caller_identity.current.account_id
+}

--- a/terraform/modules/vcf_normaliser/outputs.tf
+++ b/terraform/modules/vcf_normaliser/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda_function_arn" {
+  description = "ARN of the normalisation Lambda function"
+  value       = aws_lambda_function.normalise.arn
+}
+
+output "lambda_function_name" {
+  description = "Name of the normalisation Lambda function"
+  value       = aws_lambda_function.normalise.function_name
+}

--- a/terraform/modules/vcf_normaliser/variables.tf
+++ b/terraform/modules/vcf_normaliser/variables.tf
@@ -4,8 +4,13 @@ variable "project_name" {
 }
 
 variable "name" {
-  description = "Short identifier for this genome config, used as a suffix in resource names (e.g. 'grch38')"
+  description = "Short identifier for this genome config, used as a suffix in resource names (e.g. 'grch38'). Must contain only letters, numbers, hyphens, and underscores."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_-]+$", var.name))
+    error_message = "name must contain only letters, numbers, hyphens, and underscores."
+  }
 }
 
 variable "input_bucket_arn" {

--- a/terraform/modules/vcf_normaliser/variables.tf
+++ b/terraform/modules/vcf_normaliser/variables.tf
@@ -1,0 +1,72 @@
+variable "project_name" {
+  description = "Name prefix for all resources"
+  type        = string
+}
+
+variable "name" {
+  description = "Short identifier for this genome config, used as a suffix in resource names (e.g. 'grch38')"
+  type        = string
+}
+
+variable "input_bucket_arn" {
+  description = "ARN of the input S3 bucket"
+  type        = string
+}
+
+variable "input_prefix" {
+  description = "S3 key prefix this Lambda reads from (must end with /)"
+  type        = string
+}
+
+variable "output_prefix" {
+  description = "S3 key prefix this Lambda writes to (must end with /)"
+  type        = string
+}
+
+variable "genome_ref_bucket" {
+  description = "S3 bucket containing the reference genome FASTA"
+  type        = string
+}
+
+variable "genome_ref_key" {
+  description = "S3 key for the reference genome FASTA (.fai must be at <key>.fai)"
+  type        = string
+}
+
+variable "lambda_memory_mb" {
+  description = "Memory allocated to the Lambda function in MB"
+  type        = number
+  default     = 2048
+}
+
+variable "lambda_timeout" {
+  description = "Lambda timeout in seconds"
+  type        = number
+  default     = 600
+}
+
+variable "lambda_ephemeral_storage_mb" {
+  description = "Ephemeral storage (/tmp) for the Lambda in MB"
+  type        = number
+  default     = 4096
+}
+
+variable "ecr_image_uri" {
+  description = "Full ECR image URI including tag (e.g. 123456789.dkr.ecr.eu-west-2.amazonaws.com/vcf-normalisation:latest)"
+  type        = string
+}
+
+variable "extra_s3_prefixes" {
+  description = "Additional S3 prefix pairs (read/write) for the Lambda, e.g. for integration testing"
+  type = list(object({
+    read_prefix  = string
+    write_prefix = string
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/vcf_normaliser/variables.tf
+++ b/terraform/modules/vcf_normaliser/variables.tf
@@ -21,11 +21,21 @@ variable "input_bucket_arn" {
 variable "input_prefix" {
   description = "S3 key prefix this Lambda reads from (must end with /)"
   type        = string
+
+  validation {
+    condition     = can(regex("/$", var.input_prefix))
+    error_message = "input_prefix must end with a trailing slash."
+  }
 }
 
 variable "output_prefix" {
   description = "S3 key prefix this Lambda writes to (must end with /)"
   type        = string
+
+  validation {
+    condition     = can(regex("/$", var.output_prefix))
+    error_message = "output_prefix must end with a trailing slash."
+  }
 }
 
 variable "genome_ref_bucket" {
@@ -68,6 +78,16 @@ variable "extra_s3_prefixes" {
     write_prefix = string
   }))
   default = []
+
+  validation {
+    condition     = alltrue(flatten([for p in var.extra_s3_prefixes : [can(regex("/$", p.read_prefix)), can(regex("/$", p.write_prefix))]]))
+    error_message = "Each extra_s3_prefixes read_prefix and write_prefix must end with a trailing slash."
+  }
+
+  validation {
+    condition     = alltrue(flatten([for p in var.extra_s3_prefixes : [!can(regex("[*?]", p.read_prefix)), !can(regex("[*?]", p.write_prefix))]]))
+    error_message = "extra_s3_prefixes read_prefix and write_prefix must not contain IAM wildcard characters (* or ?)."
+  }
 }
 
 variable "tags" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,15 +1,15 @@
-output "lambda_function_arn" {
-  description = "ARN of the normalisation Lambda function"
-  value       = aws_lambda_function.normalise.arn
+output "lambda_function_arns" {
+  description = "ARN of each normalisation Lambda function, keyed by genome config name"
+  value       = { for k, v in module.normaliser : k => v.lambda_function_arn }
 }
 
-output "lambda_function_name" {
-  description = "Name of the normalisation Lambda function"
-  value       = aws_lambda_function.normalise.function_name
+output "lambda_function_names" {
+  description = "Name of each normalisation Lambda function, keyed by genome config name"
+  value       = { for k, v in module.normaliser : k => v.lambda_function_name }
 }
 
 output "ecr_repository_url" {
-  description = "URL of the ECR repository for the Lambda container image"
+  description = "URL of the shared ECR repository for the Lambda container image"
   value       = aws_ecr_repository.this.repository_url
 }
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,27 +1,30 @@
-# Account-specific configuration
-# Copy this file to terraform.tfvars and fill in the values.
-
 input_bucket_name = "my-vcf-data"
-genome_ref_bucket = "my-reference-genomes"
-genome_ref_key    = "genomes/hg38/Homo_sapiens.GRCh38.dna.toplevel.fa.gz"  # .fa or .fa.gz
 
-# Optional overrides
-# project_name              = "vcf-normalisation"
-# input_prefix              = "input/"
-# output_prefix             = "output/"
-# lambda_memory_mb          = 2048
-# lambda_timeout            = 600
+genome_configs = [
+  {
+    name              = "grch38"
+    input_prefix      = "input/grch38/"
+    output_prefix     = "output/grch38/"
+    genome_ref_bucket = "my-reference-genomes"
+    genome_ref_key    = "genomes/GRCh38/genome.fa.gz"
+  },
+  # Add a second entry here to enable a second genome, e.g.:
+  # {
+  #   name              = "grch37"
+  #   input_prefix      = "input/grch37/"
+  #   output_prefix     = "output/grch37/"
+  #   genome_ref_bucket = "my-reference-genomes"
+  #   genome_ref_key    = "genomes/GRCh37/genome.fa.gz"
+  # },
+]
+
+# Optional overrides (apply to all Lambda functions)
+# project_name                = "vcf-normalisation"
+# lambda_memory_mb            = 2048
+# lambda_timeout              = 600
 # lambda_ephemeral_storage_mb = 4096
-# ecr_image_tag             = "latest"
+# ecr_image_tag               = "latest"
 # tags = {
 #   Environment = "production"
 #   Team        = "genomics"
 # }
-
-# Grant Lambda access to additional S3 prefixes (e.g. for integration testing)
-# extra_s3_prefixes = [
-#   {
-#     read_prefix  = "test/input/"
-#     write_prefix = "test/output/"
-#   }
-# ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,40 +9,48 @@ variable "input_bucket_name" {
   type        = string
 }
 
-variable "input_prefix" {
-  description = "S3 key prefix that triggers the Lambda (must end with /)"
-  type        = string
-  default     = "input/"
+variable "genome_configs" {
+  description = <<-EOT
+    One entry per genome/prefix pair. Each entry gets its own Lambda function and
+    IAM role, named <project_name>-<name>. All entries share the same ECR repository.
+
+    Single-genome accounts (the common case) just supply one item in the list.
+  EOT
+  type = list(object({
+    name              = string # short id used in resource names, e.g. "grch38"
+    input_prefix      = string # S3 prefix to watch for incoming VCFs (must end with /)
+    output_prefix     = string # S3 prefix to write normalised VCFs (must end with /)
+    genome_ref_bucket = string # S3 bucket containing the reference FASTA
+    genome_ref_key    = string # S3 key for the FASTA (.fai must be at <key>.fai)
+    extra_s3_prefixes = optional(list(object({
+      read_prefix  = string
+      write_prefix = string
+    })), [])
+  }))
 
   validation {
-    condition     = can(regex("/$", var.input_prefix))
-    error_message = "input_prefix must end with a trailing slash."
+    condition     = length(var.genome_configs) >= 1
+    error_message = "At least one genome_config entry is required."
   }
-}
-
-variable "output_prefix" {
-  description = "S3 key prefix where normalised VCFs are written"
-  type        = string
-  default     = "output/"
 
   validation {
-    condition     = can(regex("/$", var.output_prefix))
-    error_message = "output_prefix must end with a trailing slash."
+    condition     = alltrue([for cfg in var.genome_configs : can(regex("/$", cfg.input_prefix))])
+    error_message = "Each input_prefix must end with a trailing slash."
   }
-}
 
-variable "genome_ref_bucket" {
-  description = "S3 bucket containing the reference genome (.fa and .fa.fai)"
-  type        = string
-}
+  validation {
+    condition     = alltrue([for cfg in var.genome_configs : can(regex("/$", cfg.output_prefix))])
+    error_message = "Each output_prefix must end with a trailing slash."
+  }
 
-variable "genome_ref_key" {
-  description = "S3 key for the reference genome FASTA file (the .fai index must be at <key>.fai)"
-  type        = string
+  validation {
+    condition     = length(var.genome_configs) == length(distinct([for cfg in var.genome_configs : cfg.name]))
+    error_message = "Each genome_config name must be unique."
+  }
 }
 
 variable "lambda_memory_mb" {
-  description = "Memory allocated to the Lambda function in MB"
+  description = "Memory allocated to each Lambda function in MB"
   type        = number
   default     = 2048
 }
@@ -54,7 +62,7 @@ variable "lambda_timeout" {
 }
 
 variable "lambda_ephemeral_storage_mb" {
-  description = "Ephemeral storage (/tmp) for the Lambda in MB"
+  description = "Ephemeral storage (/tmp) for each Lambda in MB"
   type        = number
   default     = 4096
 }
@@ -63,25 +71,6 @@ variable "ecr_image_tag" {
   description = "Tag of the container image in ECR to deploy"
   type        = string
   default     = "latest"
-}
-
-variable "extra_s3_prefixes" {
-  description = "Additional S3 prefix pairs (read/write) for the Lambda, e.g. for integration testing"
-  type = list(object({
-    read_prefix  = string
-    write_prefix = string
-  }))
-  default = []
-
-  validation {
-    condition     = alltrue([for p in var.extra_s3_prefixes : can(regex("/$", p.read_prefix))])
-    error_message = "Each read_prefix in extra_s3_prefixes must end with a trailing slash."
-  }
-
-  validation {
-    condition     = alltrue([for p in var.extra_s3_prefixes : can(regex("/$", p.write_prefix))])
-    error_message = "Each write_prefix in extra_s3_prefixes must end with a trailing slash."
-  }
 }
 
 variable "tags" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -57,6 +57,11 @@ variable "genome_configs" {
     condition     = alltrue([for cfg in var.genome_configs : cfg.input_prefix != cfg.output_prefix])
     error_message = "input_prefix and output_prefix must differ for each genome_config — identical prefixes would cause the Lambda to re-trigger on its own output."
   }
+
+  validation {
+    condition     = length(var.genome_configs) == length(distinct([for cfg in var.genome_configs : cfg.input_prefix]))
+    error_message = "Each genome_config input_prefix must be unique — duplicate prefixes would cause the same upload to be processed by multiple Lambdas."
+  }
 }
 
 variable "lambda_memory_mb" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,6 +47,16 @@ variable "genome_configs" {
     condition     = length(var.genome_configs) == length(distinct([for cfg in var.genome_configs : cfg.name]))
     error_message = "Each genome_config name must be unique."
   }
+
+  validation {
+    condition     = alltrue([for cfg in var.genome_configs : can(regex("^[a-zA-Z0-9_-]+$", cfg.name))])
+    error_message = "Each genome_config name must contain only letters, numbers, hyphens, and underscores (used in Lambda/IAM resource names)."
+  }
+
+  validation {
+    condition     = alltrue([for cfg in var.genome_configs : cfg.input_prefix != cfg.output_prefix])
+    error_message = "input_prefix and output_prefix must differ for each genome_config — identical prefixes would cause the Lambda to re-trigger on its own output."
+  }
 }
 
 variable "lambda_memory_mb" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -62,6 +62,55 @@ variable "genome_configs" {
     condition     = length(var.genome_configs) == length(distinct([for cfg in var.genome_configs : cfg.input_prefix]))
     error_message = "Each genome_config input_prefix must be unique — duplicate prefixes would cause the same upload to be processed by multiple Lambdas."
   }
+
+  validation {
+    condition     = length(var.genome_configs) == length(distinct([for cfg in var.genome_configs : cfg.output_prefix]))
+    error_message = "Each genome_config output_prefix must be unique — shared output prefixes allow genomes to overwrite each other's normalised files."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for cfg in var.genome_configs : [
+        for other in var.genome_configs :
+        cfg.name == other.name || !startswith(other.input_prefix, cfg.input_prefix)
+      ]
+    ]))
+    error_message = "No input_prefix may be a leading prefix of another input_prefix — overlapping prefixes cause S3 notifications to fire on unintended uploads."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for out_cfg in var.genome_configs : [
+        for in_cfg in var.genome_configs :
+        !startswith(out_cfg.output_prefix, in_cfg.input_prefix)
+      ]
+    ]))
+    error_message = "Each output_prefix must not start with any input_prefix — otherwise normalised files can re-trigger a normaliser."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for cfg in var.genome_configs : [
+        for p in cfg.extra_s3_prefixes : [
+          can(regex("/$", p.read_prefix)),
+          can(regex("/$", p.write_prefix)),
+        ]
+      ]
+    ]))
+    error_message = "Each extra_s3_prefixes read_prefix and write_prefix must end with a trailing slash."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for cfg in var.genome_configs : [
+        for p in cfg.extra_s3_prefixes : [
+          !can(regex("[*?]", p.read_prefix)),
+          !can(regex("[*?]", p.write_prefix)),
+        ]
+      ]
+    ]))
+    error_message = "extra_s3_prefixes read_prefix and write_prefix must not contain IAM wildcard characters (* or ?)."
+  }
 }
 
 variable "lambda_memory_mb" {


### PR DESCRIPTION
## Summary

- Replace flat `genome_ref_bucket` / `genome_ref_key` / `input_prefix` / `output_prefix` variables with a `genome_configs` list — each entry gets its own Lambda function and IAM role, all sharing one ECR repository
- Extract per-genome resources into `terraform/modules/vcf_normaliser/` (IAM role, IAM policy, Lambda function, Lambda permission)
- Root `main.tf` instantiates the module once per genome via `for_each`; a single `aws_s3_bucket_notification` with `dynamic` blocks covers all genomes (AWS only allows one notification resource per bucket)
- Outputs `lambda_function_arns` / `lambda_function_names` are now maps keyed by genome name (e.g. `{"grch38": "vcf-normalisation-grch38"}`)
- Single-genome accounts supply one item in `genome_configs` — same behaviour as before, variable restructure only
- Add six validation rules on `genome_configs`: list non-empty, trailing slashes, unique names, valid name characters (`^[a-zA-Z0-9_-]+$`), `input_prefix != output_prefix` (prevents infinite trigger loop), unique `input_prefix` values (prevents double-processing)
- Update README and technical_walkthrough to reflect new multi-genome structure, import commands, and scripts usage

## Test plan

- [x] `terraform validate` passes
- [ ] `terraform plan` on a single-genome tfvars produces the same resources as before (modulo module path rename)
- [ ] `terraform plan` on a two-genome tfvars produces two Lambda functions, two IAM roles, and one S3 notification with four trigger blocks
- [ ] `pytest tests/` passes (handler code unchanged)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NHS-NGS/normalisation/13)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple genome-specific normalisation paths, each with its own processing function and reference genome settings.
  * Input and output locations now work with genome-scoped prefixes, and outputs are consistently written as compressed VCF files.

* **Documentation**
  * Updated setup, deployment, and run instructions to reflect the new multi-genome configuration model.
  * Expanded examples and permissions guidance for genome-specific operations.

* **Bug Fixes**
  * Improved validation and scoping of configuration to help prevent misconfigured paths and duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->