### PR TITLE
docs: add state migration runbook for multi-genome upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ eda_haemonc_v3_norm.py
 haemonc_v3_norm_eda.ipynb
 haemonc_v3_norm_eda.html
 vcf_normalisation_session_*.md
+
+# Memory
+memory/

--- a/README.md
+++ b/README.md
@@ -125,9 +125,49 @@ terraform output -json lambda_function_names \
       --image-uri "$ECR_REPO:latest"
 ```
 
+#### Migrating existing state after upgrading to multi-genome support
+
+If your account was deployed **before** the multi-genome refactor (PR #13), the existing
+resources are at flat addresses (`aws_lambda_function.normalise`, etc.). The new config
+expects them under module paths. Run `terraform state mv` before `terraform apply` or
+Terraform will destroy and recreate the live Lambda.
+
+Substitute `<name>` with the genome name used in your `terraform.tfvars` (e.g. `grch38`):
+
+```bash
+cd terraform
+GENOME_NAME="grch38"  # match your genome_configs[].name
+
+terraform state mv \
+  aws_iam_role.lambda \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_iam_role.lambda"
+
+terraform state mv \
+  aws_iam_role_policy_attachment.lambda_basic \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_iam_role_policy_attachment.lambda_basic"
+
+terraform state mv \
+  aws_iam_role_policy.lambda_s3 \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_iam_role_policy.lambda_s3"
+
+terraform state mv \
+  aws_lambda_function.normalise \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_lambda_function.normalise"
+
+terraform state mv \
+  aws_lambda_permission.s3 \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_lambda_permission.s3"
+```
+
+ECR and S3 notification remain at the root — no migration needed for those. After moving
+state, run `terraform plan` to confirm only in-place updates are shown (no destroys), then
+`terraform apply`.
+
 #### Updating from a different machine
 
-If you are running these steps on a machine that has no local Terraform state (e.g. a fresh clone), import the existing resources before applying. The resources are now keyed by genome name, so substitute `<name>` with your `genome_configs` entry name (e.g. `grch38`):
+If you are running these steps on a machine that has no local Terraform state (e.g. a fresh
+clone of an already-deployed account), import the existing resources before applying.
+Substitute `<name>` with your `genome_configs` entry name (e.g. `grch38`):
 
 ```bash
 cd terraform
@@ -137,7 +177,8 @@ terraform import 'module.normaliser["<name>"].aws_lambda_function.normalise' vcf
 terraform import 'module.normaliser["<name>"].aws_lambda_permission.s3' vcf-normalisation-<name>/AllowS3Invoke
 ```
 
-Replace `vcf-normalisation` with your `project_name` if you changed the default. After importing, run `terraform apply` as normal.
+Replace `vcf-normalisation` with your `project_name` if you changed the default. After
+importing, run `terraform apply` as normal.
 
 ### Tearing down
 


### PR DESCRIPTION
## Summary

Existing accounts deployed before PR #13 have Terraform resources at flat addresses (`aws_lambda_function.normalise`, etc.). The new config expects them under module paths (`module.normaliser["grch38"].aws_lambda_function.normalise`). Without state migration, `terraform apply` would destroy and recreate the live Lambda.

Adds a **Migrating existing state** section to the README with the five `terraform state mv` commands needed before applying on any existing account.

Also adds `memory/` to `.gitignore`.

## Test plan
- [ ] Verify state mv commands match actual resource addresses in an existing account before applying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded migration guidance for existing deployments, including how to move older Terraform-managed resources to the new module-based structure.
  * Clarified steps for updating from another machine when no local Terraform state is available.
  * Minor wording and formatting improvements in setup instructions.

* **Chores**
  * Updated ignore rules to exclude the `memory/` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->