### PR TITLE
feat: add name_override to preserve resource names on migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ eda_haemonc_v3_norm.py
 haemonc_v3_norm_eda.ipynb
 haemonc_v3_norm_eda.html
 vcf_normalisation_session_*.md
+
+# Memory
+memory/

--- a/README.md
+++ b/README.md
@@ -125,9 +125,49 @@ terraform output -json lambda_function_names \
       --image-uri "$ECR_REPO:latest"
 ```
 
+#### Migrating existing state after upgrading to multi-genome support
+
+If your account was deployed **before** the multi-genome refactor (PR #13), the existing
+resources are at flat addresses (`aws_lambda_function.normalise`, etc.). The new config
+expects them under module paths. Run `terraform state mv` before `terraform apply` or
+Terraform will destroy and recreate the live Lambda.
+
+Substitute `<name>` with the genome name used in your `terraform.tfvars` (e.g. `grch38`):
+
+```bash
+cd terraform
+GENOME_NAME="grch38"  # match your genome_configs[].name
+
+terraform state mv \
+  aws_iam_role.lambda \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_iam_role.lambda"
+
+terraform state mv \
+  aws_iam_role_policy_attachment.lambda_basic \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_iam_role_policy_attachment.lambda_basic"
+
+terraform state mv \
+  aws_iam_role_policy.lambda_s3 \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_iam_role_policy.lambda_s3"
+
+terraform state mv \
+  aws_lambda_function.normalise \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_lambda_function.normalise"
+
+terraform state mv \
+  aws_lambda_permission.s3 \
+  "module.normaliser[\"${GENOME_NAME}\"].aws_lambda_permission.s3"
+```
+
+ECR and S3 notification remain at the root — no migration needed for those. After moving
+state, run `terraform plan` to confirm only in-place updates are shown (no destroys), then
+`terraform apply`.
+
 #### Updating from a different machine
 
-If you are running these steps on a machine that has no local Terraform state (e.g. a fresh clone), import the existing resources before applying. The resources are now keyed by genome name, so substitute `<name>` with your `genome_configs` entry name (e.g. `grch38`):
+If you are running these steps on a machine that has no local Terraform state (e.g. a fresh
+clone of an already-deployed account), import the existing resources before applying.
+Substitute `<name>` with your `genome_configs` entry name (e.g. `grch38`):
 
 ```bash
 cd terraform
@@ -137,7 +177,8 @@ terraform import 'module.normaliser["<name>"].aws_lambda_function.normalise' vcf
 terraform import 'module.normaliser["<name>"].aws_lambda_permission.s3' vcf-normalisation-<name>/AllowS3Invoke
 ```
 
-Replace `vcf-normalisation` with your `project_name` if you changed the default. After importing, run `terraform apply` as normal.
+Replace `vcf-normalisation` with your `project_name` if you changed the default. After
+importing, run `terraform apply` as normal.
 
 ### Tearing down
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,6 +63,7 @@ module "normaliser" {
 
   project_name                = var.project_name
   name                        = each.value.name
+  name_override               = each.value.name_override
   input_bucket_arn            = data.aws_s3_bucket.input.arn
   input_prefix                = each.value.input_prefix
   output_prefix               = each.value.output_prefix

--- a/terraform/modules/vcf_normaliser/main.tf
+++ b/terraform/modules/vcf_normaliser/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  resource_name = "${var.project_name}-${var.name}"
+  resource_name = coalesce(var.name_override, "${var.project_name}-${var.name}")
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/vcf_normaliser/variables.tf
+++ b/terraform/modules/vcf_normaliser/variables.tf
@@ -3,6 +3,17 @@ variable "project_name" {
   type        = string
 }
 
+variable "name_override" {
+  description = "Optional: use a fixed string as the full resource base name instead of <project_name>-<name>. Set this on an existing single-genome account to preserve current Lambda and IAM role names when migrating to the genome_configs structure."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.name_override == null || can(regex("^[a-zA-Z0-9_-]+$", var.name_override))
+    error_message = "name_override must contain only letters, numbers, hyphens, and underscores."
+  }
+}
+
 variable "name" {
   description = "Short identifier for this genome config, used as a suffix in resource names (e.g. 'grch38'). Must contain only letters, numbers, hyphens, and underscores."
   type        = string

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -10,13 +10,33 @@ genome_configs = [
   },
   # Add a second entry here to enable a second genome, e.g.:
   # {
-  #   name              = "grch37"
-  #   input_prefix      = "input/grch37/"
-  #   output_prefix     = "output/grch37/"
+  #   name              = "hg19"
+  #   input_prefix      = "input/hg19/"
+  #   output_prefix     = "output/hg19/"
   #   genome_ref_bucket = "my-reference-genomes"
-  #   genome_ref_key    = "genomes/GRCh37/genome.fa.gz"
+  #   genome_ref_key    = "genomes/hg19/genome.fa.gz"
   # },
 ]
+
+# Migrating from a pre-multi-genome deployment? Use name_override on the
+# existing genome entry to preserve current Lambda and IAM role names:
+# genome_configs = [
+#   {
+#     name              = "grch38"
+#     name_override     = "vcf-normalisation"   # keeps existing resource names
+#     input_prefix      = "input/"
+#     output_prefix     = "output/"
+#     genome_ref_bucket = "my-reference-genomes"
+#     genome_ref_key    = "genomes/GRCh38/genome.fa.gz"
+#   },
+#   {
+#     name              = "hg19"
+#     input_prefix      = "input/hg19/"
+#     output_prefix     = "output/hg19/"
+#     genome_ref_bucket = "my-reference-genomes"
+#     genome_ref_key    = "genomes/hg19/genome.fa.gz"
+#   },
+# ]
 
 # Optional overrides (apply to all Lambda functions)
 # project_name                = "vcf-normalisation"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,6 +18,7 @@ variable "genome_configs" {
   EOT
   type = list(object({
     name              = string # short id used in resource names, e.g. "grch38"
+    name_override     = optional(string, null) # preserve existing resource names when migrating
     input_prefix      = string # S3 prefix to watch for incoming VCFs (must end with /)
     output_prefix     = string # S3 prefix to write normalised VCFs (must end with /)
     genome_ref_bucket = string # S3 bucket containing the reference FASTA
@@ -51,6 +52,11 @@ variable "genome_configs" {
   validation {
     condition     = alltrue([for cfg in var.genome_configs : can(regex("^[a-zA-Z0-9_-]+$", cfg.name))])
     error_message = "Each genome_config name must contain only letters, numbers, hyphens, and underscores (used in Lambda/IAM resource names)."
+  }
+
+  validation {
+    condition     = alltrue([for cfg in var.genome_configs : cfg.name_override == null || can(regex("^[a-zA-Z0-9_-]+$", cfg.name_override))])
+    error_message = "Each genome_config name_override must contain only letters, numbers, hyphens, and underscores."
   }
 
   validation {


### PR DESCRIPTION
## Summary

Existing single-genome accounts have resources named `vcf-normalisation` (no genome suffix). After the PR #13 refactor, Terraform generates names as `<project_name>-<name>` (e.g. `vcf-normalisation-grch38`). Lambda function names are immutable — even with `terraform state mv`, Terraform would destroy and recreate the Lambda because the name in config doesn't match the name in state.

`name_override` solves this: when set, it replaces the computed `<project_name>-<name>` as the base for all resource names in the module. Existing accounts set it once on their existing genome entry; new genome entries omit it and get the standard pattern.

After this PR, the migration path for an existing account is:
1. Set `name_override = "vcf-normalisation"` on the existing genome entry in `terraform.tfvars`
2. Run `terraform state mv` to move resources to module paths
3. `terraform plan` shows zero destroys
4. `terraform apply`

## Test plan
- [ ] `terraform plan` on account `212315286023` (testbox-admin) with `name_override = "vcf-normalisation"` shows no destroys for existing resources
- [ ] New `hg19` Lambda is planned for creation with name `vcf-normalisation-hg19`
- [ ] `terraform apply` completes without errors