### PR TITLE
docs: fix stale output filename examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 terraform/.terraform/
 terraform/*.tfstate
 terraform/*.tfstate.backup
+terraform/terraform.tfstate.*.backup
 terraform/terraform.tfvars
 terraform/.terraform.lock.hcl
 

--- a/README.md
+++ b/README.md
@@ -197,14 +197,14 @@ Upload a VCF to the genome-specific `input/` prefix in your bucket. Both gzipped
 aws s3 cp sample.vcf.gz s3://my-vcf-data/input/grch38/sample.vcf.gz
 ```
 
-The normalised file appears under the corresponding `output/` prefix. Output is always bgzipped (`.vcf.gz`), regardless of whether the input was compressed:
+The normalised file appears under the corresponding `output/` prefix with `_norm` inserted before the extension. Output is always bgzipped (`.vcf.gz`), regardless of whether the input was compressed:
 
 ```bash
 # Check it arrived
-aws s3 ls s3://my-vcf-data/output/grch38/sample.vcf.gz
+aws s3 ls s3://my-vcf-data/output/grch38/sample_norm.vcf.gz
 
 # Download it
-aws s3 cp s3://my-vcf-data/output/grch38/sample.vcf.gz normalised_sample.vcf.gz
+aws s3 cp s3://my-vcf-data/output/grch38/sample_norm.vcf.gz sample_norm.vcf.gz
 ```
 
 ### Manual — re-process a file


### PR DESCRIPTION
## Summary
- README's automatic-upload example still showed pre-PR#16 output paths (`sample.vcf.gz` instead of `sample_norm.vcf.gz`) after the `_norm` suffix refactor merged in #16.
- `.gitignore`'s terraform backup pattern (`terraform/*.tfstate.backup`) didn't match the timestamped `terraform.tfstate.<epoch>.backup` files Terraform actually creates, leaving them as untracked cruft.

## Test plan
- [x] Docs-only change, no code/behaviour affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upload instructions to show the current normalized file naming and S3 output path format.
  * Revised example commands to match the expected `.vcf.gz` output name.

* **Chores**
  * Expanded ignored files to include additional Terraform state backup artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->